### PR TITLE
Workaround for mounting ZFS file systems

### DIFF
--- a/defaults/initrd.d/00-rootdev.sh
+++ b/defaults/initrd.d/00-rootdev.sh
@@ -38,6 +38,8 @@ _rootdev_detect() {
                 zfs_rootdev_init
                 if [ "${?}" = "0" ]; then
                     got_good_root=1
+		    ZFSROOT=1
+		    continue
                 else
                     got_good_root=0
                     prompt_user "REAL_ROOT" "root block device"
@@ -69,6 +71,10 @@ _rootdev_mount() {
     local mount_opts=ro
     local mount_fstype="${ROOTFSTYPE}"
     local fstype=$(get_device_fstype "${REAL_ROOT}")
+
+    if [ "${ZFSROOT}" = "1" ]; then
+        fstype=zfs_member
+    fi
 
     if is_zfs_fstype "${fstype}"; then
         [ -z "${mount_fstype}" ] && mount_fstype=zfs

--- a/defaults/initrd.defaults
+++ b/defaults/initrd.defaults
@@ -77,6 +77,7 @@ CDROOT_PATH="/mnt/cdrom"
 # This is the file that the cdroot will be checked for as a
 # marker. It must exist RELATIVE to the cdroot.
 CDROOT_MARKER="/livecd"
+ZFSROOT="0"
 
 LOOPS="/livecd.loop /zisofs /livecd.squashfs /image.squashfs /livecd.gcloop"
 


### PR DESCRIPTION
1) continue added in _rootdev_detect after ZFS detected successfully
Otherwise, it will fall through to the block file check and fail.
2) Add ZFSROOT variable which is set to 1 on successful detection of ZFS file system in _rootdev_detect
blkid check will return nothing on a ZFS file system, so I set fstype to zfs_member in _rootdev_mount if ZFSROOT is 1
