### PR TITLE
Sometimes pkg-config says /lib64/udev, qlist says /lib/udev

### DIFF
--- a/gen_initramfs.sh
+++ b/gen_initramfs.sh
@@ -275,8 +275,8 @@ append_lvm(){
     mkdir -p "${TEMP}/initramfs-lvm-temp/etc/lvm/"
     print_info 1 'LVM: Adding support (copying binaries from system)...'
 
-    local udev_dir="$(pkg-config --variable udevdir udev)"
-    udev_files=( $(qlist -e sys-fs/lvm2:0 | grep ^${udev_dir}/rules.d) )
+    local udev_dir="$(realpath $(pkg-config --variable udevdir udev))"
+    udev_files=( $(qlist -e sys-fs/lvm2:0 | xargs realpath | grep ^${udev_dir}/rules.d) )
     for f in "${udev_files[@]}"; do
         [ -f "${f}" ] || gen_die "append_lvm: not a file: ${f}"
         mkdir -p "${TEMP}/initramfs-lvm-temp"/$(dirname "${f}") || \


### PR DESCRIPTION
```
> pkg-config --variable udevdir udev
/lib/udev

> qlist -e sys-fs/lvm2:0 | grep -F /rules.d/
/lib64/udev/rules.d/11-dm-lvm.rules
/lib64/udev/rules.d/69-dm-lvm-metad.rules
/lib64/udev/rules.d/10-dm.rules
/lib64/udev/rules.d/13-dm-disk.rules
/lib64/udev/rules.d/95-dm-notify.rules
```
