### PR TITLE
Fixed case where a LUKS root is protected by a GPG-encrypted keyfile

### DIFF
--- a/gen_initramfs.sh
+++ b/gen_initramfs.sh
@@ -136,7 +136,7 @@ append_busybox() {
 
     # Set up a few default symlinks
     local default_applets="[ ash sh mount uname ls echo cut cat flock stty"
-    default_applets+=" readlink realpath mountpoint dmesg udhcpc"
+    default_applets+=" readlink realpath mountpoint dmesg udhcpc chmod mktemp"
     for i in ${BUSYBOX_APPLETS:-${default_applets}}; do
         rm -f ${TEMP}/initramfs-busybox-temp/bin/$i
         ln -s busybox ${TEMP}/initramfs-busybox-temp/bin/$i ||


### PR DESCRIPTION
...and plymouth is in use. Previously, this would use plymouth's
ask-for-password action, passing it a --command argument that
included a pipeline (line 206 in previous version of 00-crypt.sh).
As plymouth does not shell-interpret its command however, this fails.
In this version, we create a temporary script file with the necessary
pipeline command in it, and pass this temporary script to plymouth instead.
The script is in /tmp so disappears when the switch to the real root takes
place.
(In theory, it should be possible to construct a "/bin/sh -c 'cmd'"-style
invocation for the --command, thereby avoiding this, but I have had no
luck with this approach, due to plymouth's argument parser.)
I've tested this against the following cases (on Gentoo):
- using gpg encrypted keyfile for LUKS partition
- using unencrypted keyfile for LUKS partition
- using straight passphrase for LUKS partition

with both plymouth in use, and not in use (text console boot).

Obviously, for the GPG cases to work, you need to have the 
static version (with no pinentry) in your initramfs.

Best
sakaki
sakaki@deciban.com
