### PR TITLE
[ADDED] Uvesafb support with v86d helper binary

### DIFF
--- a/doc/genkernel.8.txt
+++ b/doc/genkernel.8.txt
@@ -245,6 +245,10 @@ INITIALIZATION
 *--plymouth-theme*=<theme>::
     Embeds the given plymouth theme into the initramfs.
 
+*--*[*no-*]*uvesafb*::
+    Installs, or not, the v86d helper binary into the initramfs for uvesafb
+    support. Needs the presence of the v86d binary in /sbin folder.
+
 *--do-keymap-auto*::
     Force keymap selection at boot.
 

--- a/gen_cmdline.sh
+++ b/gen_cmdline.sh
@@ -86,6 +86,8 @@ longusage() {
   echo "    --splash=<theme>    Enable framebuffer splash using <theme>"
   echo "    --splash-res=<res>  Select splash theme resolutions to install"
   echo "    --plymouth-theme=<theme>    Embed the given plymouth theme"
+  echo "    --uvesafb           Include uvesafb v86d helper support"
+  echo "    --no-uvesafb        Exclude uvesafb v86d helper support"
   echo "    --do-keymap-auto    Forces keymap selection at boot"
   echo "    --keymap        Enables keymap selection support"
   echo "    --no-keymap     Disables keymap selection support"
@@ -444,6 +446,10 @@ parse_cmdline() {
             PLYMOUTH_THEME=`parse_opt "$*"`
             print_info 2 "CMD_PLYMOUTH: ${CMD_PLYMOUTH}"
             print_info 2 "PLYMOUTH_THEME: ${PLYMOUTH_THEME}"
+            ;;
+        --uvesafb|--no-uvesafb)
+            CMD_UVESAFB=`parse_optbool "$*"`
+            print_info 2 "CMD_UVESAFB: ${CMD_UVESAFB}"
             ;;
         --install|--no-install)
             CMD_INSTALL=`parse_optbool "$*"`

--- a/gen_determineargs.sh
+++ b/gen_determineargs.sh
@@ -94,6 +94,7 @@ determine_real_args() {
 
     set_config_with_override BOOL   SPLASH               CMD_SPLASH
     set_config_with_override BOOL   PLYMOUTH             CMD_PLYMOUTH
+    set_config_with_override BOOL   UVESAFB              CMD_UVESAFB               "no"
     set_config_with_override BOOL   POSTCLEAR            CMD_POSTCLEAR
     set_config_with_override BOOL   MRPROPER             CMD_MRPROPER
     set_config_with_override BOOL   MENUCONFIG           CMD_MENUCONFIG

--- a/gen_initramfs.sh
+++ b/gen_initramfs.sh
@@ -178,6 +178,7 @@ append_e2fsprogs(){
 
     cd "${TEMP}"/initramfs-e2fsprogs-temp \
             || gen_die "cd '${TEMP}/initramfs-e2fsprogs-temp' failed"
+    log_future_cpio_content
     find . -print | cpio ${CPIO_ARGS} --append -F "${CPIO}"
     rm -rf "${TEMP}"/initramfs-e2fsprogs-temp > /dev/null
 }
@@ -512,6 +513,33 @@ append_plymouth() {
 
     cd "${TEMP}"
     rm -r "${TEMP}/initramfs-ply-temp/"
+}
+
+append_uvesafb(){
+    if [ -x "/sbin/v86d" ]
+    then
+        if [ -d "${TEMP}/initramfs-uvesafb-temp" ]
+        then
+            rm -rf "${TEMP}/initramfs-uvesafb-temp" > /dev/null
+        fi
+
+        mkdir -p ${TEMP}/initramfs-uvesafb-temp/dev
+        mkdir -p ${TEMP}/initramfs-uvesafb-temp/root
+
+        cd ${TEMP}/initramfs-uvesafb-temp/dev || gen_die "cannot cd to dev"
+        mknod -m 600 mem c 1 1 || gen_die "cannot mknod"
+
+        copy_binaries "${TEMP}/initramfs-uvesafb-temp/" /sbin/v86d
+
+        cd "${TEMP}/initramfs-uvesafb-temp/"
+        log_future_cpio_content
+        find . -print | cpio ${CPIO_ARGS} --append -F "${CPIO}" \
+                || gen_die "compressing uvesafb cpio"
+        cd "${TEMP}"
+        rm -rf "${TEMP}/initramfs-uvesafb-temp" > /dev/null
+    else
+        gen_die "uvesafb support cannot be included: No /sbin/v86d file found. Please emerge sys-apps/v86d[x86emu]."
+    fi
 }
 
 append_overlay(){
@@ -1005,6 +1033,8 @@ create_initramfs() {
 
     append_data 'plymouth' "${PLYMOUTH}"
     isTrue "${PLYMOUTH}" && append_data 'drm'
+
+    append_data 'uvesafb' "${UVESAFB}"
 
     if isTrue "${FIRMWARE}" && [ -n "${FIRMWARE_DIR}" ]
     then

--- a/genkernel.conf
+++ b/genkernel.conf
@@ -110,6 +110,9 @@ USECOLOR="yes"
 # Add new kernel to grub?
 #BOOTLOADER="grub"
 
+# Enable support for uvesafb. Default is "no"
+#UVESAFB="yes"
+
 # Enable splashutils in early space (initrd). Default is "no".
 #SPLASH="yes"
 


### PR DESCRIPTION
[ADDED] Uvesafb support with v86d helper binary
[FIXED] Missing log/debug output when adding e2fsprogs support in
initramfs

genkernel-next doesn't support using uvesafb. I am proposing my solution for this. More info (that actually will need an update when this merge hits portage) can be found in the [Gentoo Wiki here](https://wiki.gentoo.org/wiki/Uvesafb)

My proposal includes the /sbin/v86d binary that is a user helper for the kernel uvesafb module.
The required nodes for creation in the initramfs are according to the */usr/share/v86d/initramfs*
Most of them are already created in the *base_layout* subroutine of *gen_initramfs.sh*, the only ones left are */dev/mem* and */root*

I've fixed a missing logging/debug when creating the *e2fsprogs* image too.

Thanks

P.S. Do I need to create a new bug in Gentoo's bug system for this change or here it would be enough?