### PR TITLE
Open LUKS containers before mounting volumes.

### DIFF
--- a/defaults/linuxrc
+++ b/defaults/linuxrc
@@ -294,13 +294,13 @@ cd /
 
 start_iscsi
 
-start_volumes
-zfs_start_volumes
-
 setup_keymap
 
 # Initialize LUKS root device except for livecd's
 is_livecd || start_luks
+
+start_volumes
+zfs_start_volumes
 
 # Initialize resume from hibernation
 is_livecd || resume_init


### PR DESCRIPTION
As described in issue:
https://github.com/Sabayon/genkernel-next/issues/25
