### PR TITLE
udev rules: added seat rules wrt gentoo bug #517572

### DIFF
--- a/gen_initramfs.sh
+++ b/gen_initramfs.sh
@@ -616,6 +616,7 @@ append_udev() {
     udev_maybe_files="
         ${udev_dir}/rules.d/40-gentoo.rules
         ${udev_dir}/rules.d/99-systemd.rules
+        ${udev_dir}/rules.d/71-seat.rules
         /etc/modprobe.d/blacklist.conf
         /lib/systemd/network/99-default.link
     "


### PR DESCRIPTION
As described in gentoo bug #517572
https://bugs.gentoo.org/show_bug.cgi?id=517572, plymouth >= 0.9.0 does
not works correctly; this seems to be fixed adding udev rules for seats.