### PR TITLE
Added ATA over Ethernet support

### DIFF
--- a/arch/x86_64/modules_load
+++ b/arch/x86_64/modules_load
@@ -19,6 +19,9 @@ MODULES_NET="e1000 tg3"
 # iSCSI support
 MODULES_ISCSI="scsi_transport_iscsi libiscsi iscsi_tcp"
 
+# AOE support
+MODULES_AOE="aoe"
+
 # Hardware (Pluggable)
 MODULES_FIREWIRE="ieee1394 ohci1394 sbp2"
 MODULES_PCMCIA="pcmcia pcmcia_core yenta_socket pd6729 i82092 i82365 tcic ds ide-cs firmware_class"

--- a/defaults/initrd.d/00-aoe.sh
+++ b/defaults/initrd.d/00-aoe.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+. /etc/initrd.d/00-common.sh
+
+start_aoe() {
+    [ "${USE_AOE}" = "1" ] || return 0
+    
+    if [ ! -c /dev/etherd/discover ]; then
+        bad_msg "Module aoe not loaded"
+        return 0
+    fi
+
+    good_msg "Bringing up all interfaces for AOE discovery"
+    for iface in /sys/class/net/* ; do ifconfig `basename $iface` up ; done
+
+    for blk in $AOE_WAIT ; do
+        good_msg "Waiting for $blk to be discovered"
+	while [ ! -b "/dev/etherd/$blk" ] ; do
+            echo > /dev/etherd/discover
+	    sleep 1
+	done
+    done
+
+    return 0
+}
+

--- a/defaults/initrd.defaults
+++ b/defaults/initrd.defaults
@@ -85,5 +85,5 @@ DEFAULT_NFSOPTIONS="ro,nolock,rsize=1024,wsize=1024"
 
 # Only sections that are in by default or those that
 # are not module groups need to be defined here...
-HWOPTS="keymap cache modules pata sata scsi usb firewire waitscan lvm dmraid mdadm fs net virtio hyperv"
-MY_HWOPTS="modules pata sata scsi usb firewire waitscan dmraid mdadm fs net iscsi crypto plymouth virtio"
+HWOPTS="keymap cache modules pata sata scsi usb firewire waitscan lvm dmraid mdadm fs net virtio hyperv aoe"
+MY_HWOPTS="modules pata sata scsi usb firewire waitscan dmraid mdadm fs net iscsi crypto plymouth virtio aoe"

--- a/defaults/initrd.scripts
+++ b/defaults/initrd.scripts
@@ -13,4 +13,5 @@
 . /etc/initrd.d/00-crypt.sh
 . /etc/initrd.d/00-suspend.sh
 . /etc/initrd.d/00-iscsi.sh
+. /etc/initrd.d/00-aoe.sh
 . /etc/initrd.d/00-rootdev.sh

--- a/defaults/linuxrc
+++ b/defaults/linuxrc
@@ -194,7 +194,14 @@ for x in ${CMDLINE}; do
         iscsi_noibft)
             ISCSI_NOIBFT=1
         ;;
-
+	doaoe)
+	    USE_AOE=1
+	    AOE_WAIT="${AOE_WAIT-}"
+	;;
+	doaoe=*)
+	    USE_AOE=1
+	    AOE_WAIT="$AOE_WAIT ${x#*=}"
+	;;
         crypt_root=*)
             # kept for backward compatibility
             CRYPT_ROOTS=${x#*=}
@@ -293,6 +300,8 @@ is_mdev && splashcmd init
 cd /
 
 start_iscsi
+
+start_aoe
 
 start_volumes
 zfs_start_volumes

--- a/defaults/modules_load
+++ b/defaults/modules_load
@@ -19,6 +19,8 @@ MODULES_NET="e1000 tg3"
 # iSCSI support
 MODULES_ISCSI="scsi_transport_iscsi libiscsi iscsi_tcp"
 
+MODULES_AOE="aoe"
+
 # Hardware (Pluggable)
 MODULES_FIREWIRE="ieee1394 ohci1394 sbp2"
 MODULES_PCMCIA="pcmcia pcmcia_core yenta_socket pd6729 i82092 i82365 tcic ds ide-cs firmware_class"


### PR DESCRIPTION
I boot with root on ZFS over AoE, with commandline "dozfs root=ZFS doaoe=e1.0 doaoe=e1.1 doaoe=e2.0 doaoe=e2.1 [...]" where each "doaoe" argument lists an AoE target drive that needs to be discovered before boot can continue (and root filesystem mounted). Any filesystem should work.

Cheers!