### PR TITLE
add `--firmware-src` and `--firmware-dst` options

### DIFF
--- a/gen_cmdline.sh
+++ b/gen_cmdline.sh
@@ -152,8 +152,14 @@ longusage() {
   echo "    --firmware"
   echo "                Enable copying of firmware into initramfs"
   echo "    --firmware-dir=<dir>"
+  echo "    --firmware-src=<dir>"
+  echo "                Implies --firmware."
   echo "                Specify directory to copy firmware from (defaults"
-  echo "                to /lib/firmware)"
+  echo "                to --firmware-dst setting)"
+  echo "    --firmware-dst=<dir>"
+  echo "                                Implies --firmware."
+  echo "                Specify directory to install firmware to (defaults"
+  echo "                                to /lib/firmware)"
   echo "    --firmware-files=<files>"
   echo "                Specifies specific firmware files to copy. This"
   echo "                overrides --firmware-dir. For multiple files,"
@@ -567,10 +573,20 @@ parse_cmdline() {
             CMD_FIRMWARE=`parse_optbool "$*"`
             print_info 2 "CMD_FIRMWARE: ${CMD_FIRMWARE}"
             ;;
-        --firmware-dir=*)
-            CMD_FIRMWARE_DIR=`parse_opt "$*"`
+        --firmware-dst=*)
+            CMD_FIRMWARE_DST=`parse_opt "$*"`
             CMD_FIRMWARE=1
-            print_info 2 "CMD_FIRMWARE_DIR: ${CMD_FIRMWARE_DIR}"
+            print_info 2 "CMD_FIRMWARE_DST: ${CMD_FIRMWARE_DST}"
+            ;;
+        --firmware-dir=*)
+            CMD_FIRMWARE_SRC=`parse_opt "$*"`
+            CMD_FIRMWARE=1
+            print_info 2 "CMD_FIRMWARE_SRC: ${CMD_FIRMWARE_SRC}"
+            ;;
+        --firmware-src=*)
+            CMD_FIRMWARE_SRC=`parse_opt "$*"`
+            CMD_FIRMWARE=1
+            print_info 2 "CMD_FIRMWARE_SRC: ${CMD_FIRMWARE_SRC}"
             ;;
         --firmware-files=*)
             CMD_FIRMWARE_FILES=`parse_opt "$*"`

--- a/gen_compile.sh
+++ b/gen_compile.sh
@@ -25,6 +25,8 @@ compile_kernel_args() {
     then
         ARGS="${ARGS} O=\"${KERNEL_OUTPUTDIR}\""
     fi
+    # tweak destination for firmware install...
+    ARGS="${ARGS} INSTALL_FW_PATH=\"${FIRMWARE_DST}\""
     echo -n "${ARGS}"
 }
 

--- a/gen_determineargs.sh
+++ b/gen_determineargs.sh
@@ -130,7 +130,8 @@ determine_real_args() {
     set_config_with_override BOOL   VIRTIO               CMD_VIRTIO               "no"
     set_config_with_override BOOL   MULTIPATH            CMD_MULTIPATH
     set_config_with_override BOOL   FIRMWARE             CMD_FIRMWARE
-    set_config_with_override STRING FIRMWARE_DIR         CMD_FIRMWARE_DIR         "/lib/firmware"
+    set_config_with_override STRING FIRMWARE_DST         CMD_FIRMWARE_DST         "/lib/firmware"
+    set_config_with_override STRING FIRMWARE_SRC         CMD_FIRMWARE_SRC         "$FIRMWARE_DST"
     set_config_with_override STRING FIRMWARE_FILES       CMD_FIRMWARE_FILES
     set_config_with_override BOOL   INTEGRATED_INITRAMFS CMD_INTEGRATED_INITRAMFS
     set_config_with_override BOOL   GENZIMAGE            CMD_GENZIMAGE

--- a/gen_initramfs.sh
+++ b/gen_initramfs.sh
@@ -574,9 +574,9 @@ append_luks() {
 }
 
 append_firmware() {
-    if [ -z "${FIRMWARE_FILES}" -a ! -d "${FIRMWARE_DIR}" ]
+    if [ -z "${FIRMWARE_FILES}" -a ! -d "${FIRMWARE_SRC}" ]
     then
-        gen_die "specified firmware directory (${FIRMWARE_DIR}) does not exist"
+        gen_die "specified firmware directory (${FIRMWARE_SRC}) does not exist"
     fi
     if [ -d "${TEMP}/initramfs-firmware-temp" ]
     then
@@ -594,7 +594,7 @@ append_firmware() {
         done
         IFS=$OLD_IFS
     else
-        cp -a "${FIRMWARE_DIR}"/* ${TEMP}/initramfs-firmware-temp/lib/firmware/
+        cp -a "${FIRMWARE_SRC}"/* ${TEMP}/initramfs-firmware-temp/lib/firmware/
     fi
     log_future_cpio_content
     find . -print | cpio ${CPIO_ARGS} --append -F "${CPIO}" \
@@ -1028,7 +1028,7 @@ create_initramfs() {
     append_data 'plymouth' "${PLYMOUTH}"
     isTrue "${PLYMOUTH}" && append_data 'drm'
 
-    if isTrue "${FIRMWARE}" && [ -n "${FIRMWARE_DIR}" ]
+    if isTrue "${FIRMWARE}" && [ -n "${FIRMWARE_SRC}" ]
     then
         append_data 'firmware'
     fi

--- a/genkernel.conf
+++ b/genkernel.conf
@@ -103,9 +103,9 @@ USECOLOR="yes"
 # Enable copying of firmware into initramfs
 #FIRMWARE="no"
 # Specify directory to pull from
-#FIRMWARE_DIR="/lib/firmware"
-# Specify specific firmware files to include. This overrides FIRMWARE_DIR
-#FIRMWARE_FILES=""
+# FIRMWARE_SRC="/lib/firmware"
+# Specify specific firmware files to include. This overrides FIRMWARE_SRC
+# FIRMWARE_FILES=""
 
 # Add new kernel to grub?
 #BOOTLOADER="grub"


### PR DESCRIPTION
Make sure genkernel-next is ready for usage in ebuild environment.

Related: https://bugs.gentoo.org/show_bug.cgi?id=600262
Related: https://github.com/tehcaster/gentoo-kernel-overlay/issues/2