### PR TITLE
Use KERNEL_OUTPUTDIR for integrated initramfs configuration

### DIFF
--- a/gen_initramfs.sh
+++ b/gen_initramfs.sh
@@ -1084,8 +1084,8 @@ create_initramfs() {
     then
         # Explicitly do not compress if we are integrating into the kernel.
         # The kernel will do a better job of it than us.
-        mv ${TMPDIR}/initramfs-${KV} ${TMPDIR}/initramfs-${KV}.cpio
-        sed -i '/^.*CONFIG_INITRAMFS_SOURCE=.*$/d' ${KERNEL_DIR}/.config
+        mv "${TMPDIR}"/initramfs-"${KV}" "${TMPDIR}"/initramfs-"${KV}".cpio
+        sed -i '/^.*CONFIG_INITRAMFS_SOURCE=.*$/d' "${KERNEL_OUTPUTDIR}"/.config
         compress_config='INITRAMFS_COMPRESSION_NONE'
         case ${compress_ext} in
             gz)  compress_config='INITRAMFS_COMPRESSION_GZIP' ;;
@@ -1098,7 +1098,7 @@ create_initramfs() {
         esac
         # All N default except XZ, so there it gets used if the kernel does
         # compression on it's own.
-        cat >> ${KERNEL_DIR}/.config << EOF
+        cat >> "${KERNEL_OUTPUTDIR}/".config << EOF
 CONFIG_INITRAMFS_SOURCE="${TMPDIR}/initramfs-${KV}.cpio${compress_ext}"
 CONFIG_INITRAMFS_ROOT_UID=0
 CONFIG_INITRAMFS_ROOT_GID=0


### PR DESCRIPTION
`--integrated-initramfs` builds the kernel in 2 passes, and modifies the kernel configuration in-between.
However it uses `${KERNEL_DIR}/.config`, which is in the kernel source tree. While this does work for in-tree builds, it makes out-of-tree builds fail since the source tree then appears unclean (and the written `.config` file only contains the `CONFIG_INITRAMFS_*` items anyway).

This PR switches to `${KERNEL_OUTPUTDIR}/.config` which should be the right path both for in-tree and out-of-tree builds.

