### PR TITLE
Fsck b4 mount

### DIFF
--- a/defaults/initrd.defaults
+++ b/defaults/initrd.defaults
@@ -87,3 +87,10 @@ DEFAULT_NFSOPTIONS="ro,nolock,rsize=1024,wsize=1024"
 # are not module groups need to be defined here...
 HWOPTS="keymap cache modules pata sata scsi usb firewire waitscan lvm dmraid mdadm fs net virtio hyperv"
 MY_HWOPTS="modules pata sata scsi usb firewire waitscan dmraid mdadm fs net iscsi crypto plymouth virtio"
+
+# Location of the busybox (if included).
+BUSYBOX_BIN=/bin/busybox
+# Location of the fs repair tool (if included).
+REAL_E2FSCK_BIN=/sbin/e2fsck
+# Options: -p = auto-repair, -C0 = write progress bar
+REAL_E2FSCK_BIN_OPTS="-p -C0"


### PR DESCRIPTION
The changes add support for checking the integrity of
filesystems mounted from within the initramfs.

Systemd wants the filesystem on which /usr resides mounted when
it finally takes over from initramfs, but does not seem to
launch a systemd-fsck job for that filesystem later on, even if
the filesystem is mounted ro.  The result is that the
/usr-hosting filesystem could go unchecked for a long time.

The problem is not limited to /usr, but all early mounts
mentioned in initramfs.mounts.

Furthermore, fsck'ing should work on the physical device, final
mounting should take into account existing symbolic or logical
disk/LVM names for the purpose of enhanced readability.