### PR TITLE
Fix quoting error inside command substitution

### DIFF
--- a/defaults/initrd.d/00-modules.sh
+++ b/defaults/initrd.d/00-modules.sh
@@ -78,7 +78,7 @@ cmdline_hwopts() {
             if [ "${y}" = "do${x}" ]; then
                 MY_HWOPTS="${MY_HWOPTS} $x"
             elif [ "${y}" = "no${x}" ]; then
-                MY_HWOPTS="$(echo ${MY_HWOPTS} | sed -e \"s/${x}//g\" -)"
+                MY_HWOPTS="$(echo ${MY_HWOPTS} | sed -e "s/${x}//g" -)"
             fi
         done
     done


### PR DESCRIPTION
The current quoting triggers an error from `sed`.
Quotes inside command substitution (`$()`) should not be escaped, otherwise they are passed literally. Thus the `unknown command: "` error from `sed`.