### PR TITLE
modules_load: add ecb crypto module

### DIFF
--- a/arch/x86/modules_load
+++ b/arch/x86/modules_load
@@ -28,7 +28,7 @@ MODULES_USB="ehci-pci ehci-hcd uhci usb-ohci hid usb-storage uhci-hcd ohci-pci o
 MODULES_FS="ext2 ext3 ext4 btrfs reiserfs jfs nfs xfs zfs overlay fuse"
 
 # Crypto
-MODULES_CRYPTO="sha1_generic sha256_generic sha512_generic cbc aes_generic aes-x86_64 xts"
+MODULES_CRYPTO="sha1_generic sha256_generic sha512_generic cbc ecb aes_generic aes-x86_64 xts"
 # Backward compatibility with previous releases
 MODULES_CRYPT="${MODULES_CRYPTO}"
 

--- a/arch/x86_64/modules_load
+++ b/arch/x86_64/modules_load
@@ -28,7 +28,7 @@ MODULES_USB="ehci-pci ehci-hcd uhci usb-ohci hid usb-storage uhci-hcd ohci-pci o
 MODULES_FS="ext2 ext3 ext4 btrfs reiserfs jfs nfs xfs zfs overlay fuse"
 
 # Crypto
-MODULES_CRYPTO="sha1_generic sha256_generic sha512_generic cbc aes_generic aes-x86_64 xts"
+MODULES_CRYPTO="sha1_generic sha256_generic sha512_generic cbc ecb aes_generic aes-x86_64 xts"
 # Backward compatibility with previous releases
 MODULES_CRYPT="${MODULES_CRYPTO}"
 

--- a/defaults/modules_load
+++ b/defaults/modules_load
@@ -28,7 +28,7 @@ MODULES_USB="ehci-hcd uhci usb-ohci hid usb-storage uhci-hcd ohci-pci ohci-hcd x
 MODULES_FS="ext2 ext3 ext4 btrfs reiserfs jfs nfs xfs zfs overlay fuse"
 
 # Crypto
-MODULES_CRYPTO="sha1_generic sha256_generic sha512_generic cbc aes_generic aes-x86_64 xts"
+MODULES_CRYPTO="sha1_generic sha256_generic sha512_generic cbc ecb aes_generic aes-x86_64 xts"
 # Backward compatibility with previous releases
 MODULES_CRYPT="${MODULES_CRYPTO}"
 


### PR DESCRIPTION
Some LUKS volumes depend on "ECB block cipher algorithm" if not included
in the bzImage or at modules in initramfs we get that kind of messages
bellow and fail to boot.

device-mapper: reload ioctl failed: No such file or directory
Failed to setup dm-crypt key mapping for device /dev/vda2.
Check that kernel supports aes-xts-plain cipher (check syslog for more info).

dmesg:
[    7.402907] device-mapper: table: 253:0: crypt: Error allocating crypto tfm
[    7.402910] device-mapper: ioctl: error adding target to table

luksDump:
Version:       	1
Cipher name:   	aes
Cipher mode:   	xts-plain
Hash spec:     	sha256

Include ecb module resolve the issue.