### PR TITLE
Adding support for detached headers for crypto root

### DIFF
--- a/defaults/linuxrc
+++ b/defaults/linuxrc
@@ -225,6 +225,12 @@ for x in ${CMDLINE}; do
         root_trim=*)
             CRYPT_ROOT_TRIM=${x#*=}
         ;;
+        root_header=*)
+            CRYPT_ROOT_HEADER=${x#*=}
+        ;;
+        root_headerdev=*)
+            CRYPT_ROOT_HEADERDEV=${x#*=}
+        ;;
 
         swap_key=*)
             CRYPT_SWAP_KEY=${x#*=}


### PR DESCRIPTION
I basically copied the code for the key and adapted it bit to do the headers.
Working fine on my gentoo box.
Looking something like this then in default/grub
GRUB_CMDLINE_LINUX="crypt_roots=/dev/disk/by-id/ata-Samsung_SSD_850_EVO_250GB_S2R6NX0J363411N-part1 root_header=/luks-header root_headerdev=UUID=cadca53c-3a05-4ed2-84fe-f2d1d03e812e root_trim=yes dolvm quiet spalsh"

If used it will need more testing as I only have my one box where I'm running it.

Feel free to use or discard as you feel.
If you have, feedback would be appreciated