### PR TITLE
Add kernel module compression (gzip, xz) support

### DIFF
--- a/gen_initramfs.sh
+++ b/gen_initramfs.sh
@@ -777,7 +777,7 @@ print_list()
 append_modules() {
     local group
     local group_modules
-    local MOD_EXT=".ko"
+    local MOD_EXT=$(modules_kext)
 
     print_info 2 "initramfs: >> Searching for modules..."
     if [ "${INSTALL_MOD_PATH}" != '' ]
@@ -821,7 +821,7 @@ append_modules() {
 }
 
 append_drm() {
-    local MOD_EXT=".ko"
+    local MOD_EXT=$(modules_kext)
 
     print_info 2 "initramfs: >> Appending drm drivers..."
     if [ "${INSTALL_MOD_PATH}" != '' ]

--- a/gen_moddeps.sh
+++ b/gen_moddeps.sh
@@ -4,6 +4,10 @@
 modules_kext()
 {
     KEXT=".ko"
+    if grep -sq '^CONFIG_MODULE_COMPRESS=y' "${KERNEL_DIR}"/.config; then
+    grep -sq '^CONFIG_MODULE_COMPRESS_XZ=y' "${KERNEL_DIR}"/.config && KEXT='.ko.xz'
+    grep -sq '^CONFIG_MODULE_COMPRESS_GZIP=y' "${KERNEL_DIR}"/.config && KEXT='.ko.gz'
+    fi
     echo ${KEXT}
 }
 


### PR DESCRIPTION
Currently genkernel-next doesn't support handling compressed kernel module(*.ko.gz or *.ko.xz)
This fix makes it possible. It's from Gentoo's genkernel tree [1] and maybe better use for Gentoo user.

[1] https://gitweb.gentoo.org/proj/genkernel.git/commit/?id=a79ecbd06cf71b3ac5abd2675601a0d750a9908c
