### PR TITLE
Fix for issue #63

### DIFF
--- a/gen_initramfs.sh
+++ b/gen_initramfs.sh
@@ -654,7 +654,7 @@ append_udev() {
     udev_maybe_files="
         ${udev_dir}/rules.d/40-gentoo.rules
         ${udev_dir}/rules.d/99-systemd.rules
-        ${udev_dir}/rules.d/71-seat.rules
+        ${udev_dir}/rules.d/71-udev-seat.rules
         /etc/modprobe.d/blacklist.conf
         ${systemd_dir}/network/99-default.link
     "


### PR DESCRIPTION
Solves https://github.com/Sabayon/genkernel-next/issues/63 by updating the udev rules filename