### PR TITLE
Adding Compressed modules

### DIFF
--- a/defaults/linuxrc
+++ b/defaults/linuxrc
@@ -19,6 +19,9 @@ mount -t tmpfs -o rw,nosuid,nodev,relatime,mode=755 none /run 2>&1
 
 /bin/busybox --install -s
 
+#Reck Modules
+depmod -a
+
 if [ "$0" = "/init" ]; then
     rm -f /linuxrc
 fi

--- a/gen_initramfs.sh
+++ b/gen_initramfs.sh
@@ -777,7 +777,7 @@ print_list()
 append_modules() {
     local group
     local group_modules
-    local MOD_EXT=".ko"
+    local MOD_EXT=`modules_kext`
 
     print_info 2 "initramfs: >> Searching for modules..."
     if [ "${INSTALL_MOD_PATH}" != '' ]
@@ -821,7 +821,7 @@ append_modules() {
 }
 
 append_drm() {
-    local MOD_EXT=".ko"
+    local MOD_EXT=`modules_kext`
 
     print_info 2 "initramfs: >> Appending drm drivers..."
     if [ "${INSTALL_MOD_PATH}" != '' ]

--- a/gen_moddeps.sh
+++ b/gen_moddeps.sh
@@ -4,6 +4,19 @@
 modules_kext()
 {
     KEXT=".ko"
+#Testing modules compressiona to add right extension
+#CONFIG_MODULE_COMPRESS_XZ=y
+#CONFIG_MODULE_COMPRESS_GZIP=y
+
+if [ xy == x`kconfig_get_opt ${KERNEL_CONFIG} "CONFIG_MODULE_COMPRESS"` ] 
+then
+	if [ "xy" = x`kconfig_get_opt ${KERNEL_CONFIG} "CONFIG_MODULE_COMPRESS_XZ"` ]
+	then
+		KEXT="$KEXT.xz"
+	else
+		KEXT="$KEXT.gz"
+	fi
+fi
     echo ${KEXT}
 }
 


### PR DESCRIPTION
Hi,

If you compress modules with CONFIG_MODULE_COMPRESS
genkernel could not find **.ko.(gz|xz)** modules.

- update changes modules_kext() to configure right $KEXT with kernel parameters
- When booting, modules are not correctly find unless you run depmod -a (probably a better solution than running on each boot)
- Minor change typo