### PR TITLE
Delete mdassemble, removed upstream by mdadm

### DIFF
--- a/gen_initramfs.sh
+++ b/gen_initramfs.sh
@@ -348,9 +348,9 @@ append_mdadm(){
         cp "${f}" "${TEMP}/initramfs-mdadm-temp/${f}" || \
             gen_die "cannot copy ${f} from system"
     done
-    
+
     copy_binaries "${TEMP}/initramfs-mdadm-temp" \
-        /sbin/mdadm /sbin/mdmon /sbin/mdassemble
+        /sbin/mdadm /sbin/mdmon
 
     if [ -n "${MDADM_CONFIG}" ]
     then


### PR DESCRIPTION
Fix #74

https://github.com/Sabayon/genkernel-next/issues/74
https://bugs.gentoo.org/669792