### PR TITLE
Add support for merging kernel config fragment

### DIFF
--- a/gen_cmdline.sh
+++ b/gen_cmdline.sh
@@ -23,6 +23,8 @@ longusage() {
   echo "    --color         Output debug in color"
   echo "    --no-color      Do not output debug in color"
   echo "  Kernel Configuration settings"
+  echo "    --mergekconfig      Run merge_config.sh instead of oldconfig"
+  echo "    --no-mergekconfig   Do not run merge_config.sh instead of oldconfig"
   echo "    --menuconfig        Run menuconfig after oldconfig"
   echo "    --no-menuconfig     Do not run menuconfig after oldconfig"
   echo "    --nconfig       Run nconfig after oldconfig"
@@ -357,6 +359,10 @@ parse_cmdline() {
             CMD_LOGLEVEL=`parse_opt "$*"`
             LOGLEVEL="${CMD_LOGLEVEL}"
             print_info 2 "CMD_LOGLEVEL: ${CMD_LOGLEVEL}"
+            ;;
+        --mergekconfig|--no-mergekconfig)
+            CMD_MERGE_KCONFIG=`parse_optbool "$*"`
+            print_info 2 "CMD_MERGE_KCONFIG: ${CMD_MERGE_KCONFIG}"
             ;;
         --menuconfig)
             TERM_LINES=`stty -a | head -n 1 | cut -d\  -f5 | cut -d\; -f1`

--- a/gen_configkernel.sh
+++ b/gen_configkernel.sh
@@ -65,6 +65,20 @@ config_kernel() {
         fi
     fi
 
+    # Support kernel config fragment merging.
+    if isTrue "${MERGE_KCONFIG}"
+    then
+        KCONFIG_FRAGMENT=${KCONFIG_FRAGMENT:-/etc/default/genkernel_kconfig_fragment}
+        local message="Error: Config fragment ${KCONFIG_FRAGMENT} not found!"
+        print_info 1 "kernel: Merging config with ${KCONFIG_FRAGMENT}"
+        [[ -f "${KCONFIG_FRAGMENT}" ]] || gen_die  "${message}"
+        KCONFIG_CONFIG="${KERNEL_OUTPUTDIR}/.config" \
+            "${KERNEL_DIR}"/scripts/kconfig/merge_config.sh \
+            "${KERNEL_OUTPUTDIR}/.config" \
+            "${KCONFIG_FRAGMENT[@]}"
+        [[ "$?" ]] || gen_die "Error: merge_config.sh failed!"
+    fi
+
     if isTrue "${OLDCONFIG}"
     then
         print_info 1 '        >> Running oldconfig...'

--- a/gen_determineargs.sh
+++ b/gen_determineargs.sh
@@ -97,6 +97,7 @@ determine_real_args() {
     set_config_with_override BOOL   PLYMOUTH             CMD_PLYMOUTH
     set_config_with_override BOOL   POSTCLEAR            CMD_POSTCLEAR
     set_config_with_override BOOL   MRPROPER             CMD_MRPROPER
+    set_config_with_override BOOL   MERGE_KCONFIG        CMD_MERGE_KCONFIG
     set_config_with_override BOOL   MENUCONFIG           CMD_MENUCONFIG
     set_config_with_override BOOL   NCONFIG              CMD_NCONFIG
     set_config_with_override BOOL   CLEAN                CMD_CLEAN
@@ -185,6 +186,12 @@ determine_real_args() {
         then
             gen_die 'Kernel Cache specified but no kernel tree to verify against!'
         fi
+    fi
+
+    # After merging config fragments, make alldefconfig is run by default
+    if isTrue ${MERGE_KCONFIG}
+    then
+        OLDCONFIG=0
     fi
 
     # Special case:  If --no-clean is specified on the command line,

--- a/genkernel.conf
+++ b/genkernel.conf
@@ -41,6 +41,11 @@ MOUNTBOOT="yes"
 # Make symlinks in BOOTDIR automatically?
 #SYMLINK="no"
 
+# Merge kernel config fragment
+#MERGE_KCONFIG="yes"
+# Kernel config fragment(s) to merge
+#KCONFIG_FRAGMENT=( "/etc/default/genkernel_kconfig_fragment" )
+
 # Save the new configuration in /etc/kernels upon
 # successfull compilation
 SAVE_CONFIG="yes"


### PR DESCRIPTION
Use merge_config.sh that comes with kernel sources since v3.4.

By default look for kernel config fragment to merge in
/etc/default/genkernel_kconfig_fragment which can be overridden by
setting KCONFIG_FRAGMENT.

If KCONFIG_FRAGMENT is an array, merge all fragments.