### PR TITLE
Try to find a previous kernel config for x.y.*

### DIFF
--- a/gen_configkernel.sh
+++ b/gen_configkernel.sh
@@ -3,6 +3,7 @@
 
 # Fills variable KERNEL_CONFIG
 determine_config_file() {
+    local prev_kconf=$(ls -v "/etc/kernels/kernel-config-${ARCH}-${VER}.${PAT}."* 2>/dev/null | grep -v '.old$' | tail -1)
     if [ "${CMD_KERNEL_CONFIG}" != "" ]
     then
         KERNEL_CONFIG="${CMD_KERNEL_CONFIG}"
@@ -12,6 +13,9 @@ determine_config_file() {
     elif [ -f "${GK_SHARE}/arch/${ARCH}/kernel-config-${KV}" ]
     then
         KERNEL_CONFIG="${GK_SHARE}/arch/${ARCH}/kernel-config-${KV}"
+    elif [ -f "${prev_kconf}" ]
+    then
+        KERNEL_CONFIG="${prev_kconf}"
     elif [ "${DEFAULT_KERNEL_CONFIG}" != "" -a -f "${DEFAULT_KERNEL_CONFIG}" ]
     then
         KERNEL_CONFIG="${DEFAULT_KERNEL_CONFIG}"


### PR DESCRIPTION
If kernel config for the current version is not found, try finding a previous one for the current release.

This eases weekly kernel updates for patch levels x.y.(z+1).

Config updates for kernel releases x.(y+1) still have to be reviewed by the user since there are large changes every release.

I did not put in any guards for ancient kernels which had four-number versions for patch levels.